### PR TITLE
Handle empty system_profiler XML data (on OS X)

### DIFF
--- a/src/readers/mac.php
+++ b/src/readers/mac.php
@@ -165,6 +165,11 @@ class ezcSystemInfoMacReader extends ezcSystemInfoReader
         
         $hwInfo = shell_exec( "system_profiler -xml -detailLevel mini SPHardwareDataType" );
 
+        // Abort if sysinfo XML is blank
+        if($hwInfo == ''){
+                return true;
+        }
+
         $reader = new XMLReader();
         $reader->XML( $hwInfo );
 


### PR DESCRIPTION
On OS X 10.11.3 and PHP 7.0.4 installed from Brew shell_exec fails to execute system_profiler. This fix simply checks if the string is empty and aborts if it is.