### PR TITLE
Prevent XML reader error when `shell_exec` returns nothing

### DIFF
--- a/src/readers/mac.php
+++ b/src/readers/mac.php
@@ -164,6 +164,11 @@ class ezcSystemInfoMacReader extends ezcSystemInfoReader
         $allValuesDetected = false;
         
         $hwInfo = shell_exec( "system_profiler -xml -detailLevel mini SPHardwareDataType" );
+        // Prevent XML reader error when shell_exec returns nothing
+        if ( empty( trim( $hwInfo ) ) )
+        {
+            return false;
+        }
 
         $reader = new XMLReader();
         $reader->XML( $hwInfo );


### PR DESCRIPTION
The PHP user does not always find the system profiler utility is its `$PATH`. 
Adding this verification prevents an error due to the `shell_exec` command returning nothing.