### PR TITLE
Use complete path to system_profiler

### DIFF
--- a/src/readers/mac.php
+++ b/src/readers/mac.php
@@ -163,7 +163,7 @@ class ezcSystemInfoMacReader extends ezcSystemInfoReader
                                      "physical_memory" );
         $allValuesDetected = false;
         
-        $hwInfo = shell_exec( "system_profiler -xml -detailLevel mini SPHardwareDataType" );
+        $hwInfo = shell_exec( "/usr/sbin/system_profiler -xml -detailLevel mini SPHardwareDataType" );
 
         $reader = new XMLReader();
         $reader->XML( $hwInfo );


### PR DESCRIPTION
On some machines the `$PATH` used by PHP does not contain `/usr/sbin/`, where system_profiler now resides. Feel free to use a less restrictive command.