### PR TITLE
linux.php: Handle nulls when some CPU infos aren't available.

### DIFF
--- a/src/readers/linux.php
+++ b/src/readers/linux.php
@@ -253,6 +253,9 @@ class ezcSystemInfoLinuxReader extends ezcSystemInfoReader
      */
     public function cpuSpeed()
     {
+        if ( $this->cpuSpeed === null ) {
+            return null;
+        }
         $totalSpeed = 0;
         foreach ( $this->cpuSpeed as $speed )
         {
@@ -270,7 +273,7 @@ class ezcSystemInfoLinuxReader extends ezcSystemInfoReader
      */
     public function cpuType()
     {
-        return $this->cpuType[0];
+        return $this->cpuType[0] ?? null;
     }
 
     /**


### PR DESCRIPTION
If `cpuType` couldn't be retrieved and is still null, accessing its first element throw an error "Trying to access array offset on value of type null". The change respects `@return string the CPU type or null`.

If `cpuSpeed` couldn't be retrieved and is still null, trying to loop in it throw an error "Invalid argument supplied for foreach()". The change respects `@return float with speed of CPU or null`.